### PR TITLE
feat: Add AWS deployment guide and update CI/CD for ECR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,21 @@ jobs:
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           
 
-      # Step 7: (Optional, but highly recommended) Build and tag the Docker image
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+      # Step 7: Build and tag the Docker image and push to ECR
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1 # Your AWS region
 
-      - name: Build and Push Docker Image
-        uses: docker/build-push-action@v4
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and Push Docker Image to ECR
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/smart-home-api:latest
+          tags: 126836729502.dkr.ecr.eu-central-1.amazonaws.com/smart-home-api:latest

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ You can also run the API directly on your machine, connecting to a local or Dock
     ```
     The API will be available at `http://localhost:3000`.
 
+## 🚀 Deployment to AWS
+
+This project is designed for cloud deployment. A detailed guide on how to deploy this application to AWS, including setting up AWS CLI, ECR, and pushing Docker images, can be found in the [AWS Deployment Guide](docs/aws-deployment-guide.md).
+
 ## 📚 Project Evolution: A Day-by-Day Journey
 
 ### Day 1: Project Initialization & Enterprise Setup

--- a/docs/aws-deployment-guide.md
+++ b/docs/aws-deployment-guide.md
@@ -1,0 +1,61 @@
+This guide outlines the complete process of building and deploying a containerized Node.js application to Amazon Web Services (AWS), following modern DevOps best practices.
+
+### **1. Containerization with Docker**
+
+The first step is to containerize your application. A `Dockerfile` defines the environment and instructions for building a Docker image, which packages your application and its dependencies. This ensures consistency across development and production environments.
+
+  * **Create a `Dockerfile`**: A multi-stage build is used to create a lean, secure image.
+
+      * **Builder Stage**: Compiles and bundles the application.
+      * **Production Stage**: Copies only the essential build artifacts into a lightweight base image to reduce the final image size and attack surface.
+
+  * **Build the Docker Image**: The image is built from the `Dockerfile` and tagged with a name and version.
+
+    ```bash
+    docker build -t smart-home-api:v1.0.0 .
+    ```
+
+-----
+
+### **2. AWS Environment Setup**
+
+Before deployment, we set up the necessary cloud infrastructure on AWS, ensuring a secure and efficient workflow.
+
+  * **Create an IAM User**: A dedicated IAM user with programmatic access was created to follow the principle of least privilege. This user has specific permissions to interact with AWS services without using the root account.
+  * **Create an ECR Repository**: AWS Elastic Container Registry (ECR) was used as a private, secure Docker registry to store the application's image.
+
+-----
+
+### **3. Authentication and Image Push**
+
+With the AWS environment prepared, we authenticated our local machine to securely interact with the cloud.
+
+  * **Install and Configure AWS CLI**: The AWS Command Line Interface was installed and configured using the access key and secret key from the IAM user. This establishes a secure connection between your terminal and your AWS account.
+
+    ```bash
+    aws configure
+    ```
+
+  * **Authenticate Docker with ECR**: A temporary token was retrieved from AWS to allow Docker to securely log in to the ECR repository.
+
+    ```bash
+    aws ecr get-login-password --region eu-central-1 | docker login --username AWS --password-stdin 126836729502.dkr.ecr.eu-central-1.amazonaws.com
+    ```
+
+  * **Tag the Docker Image**: The locally built image was tagged with the ECR repository URI to prepare it for upload.
+
+    ```bash
+    docker tag smart-home-api:v1.0.0 126836729502.dkr.ecr.eu-central-1.amazonaws.com/smart-home-api:v1.0.0
+    ```
+
+  * **Push the Image to ECR**: The final, tagged image was pushed to the private ECR repository.
+
+    ```bash
+    docker push 126836729502.dkr.ecr.eu-central-1.amazonaws.com/smart-home-api:v1.0.0
+    ```
+
+-----
+
+### **4. Final Outcome**
+
+By completing these steps, you have successfully deployed your application's Docker image to the cloud. This image is now securely stored in a private registry and is ready to be pulled by a container orchestration service like AWS ECS or Kubernetes for production deployment.


### PR DESCRIPTION
This commit introduces a new AWS deployment guide in the `docs` directory.

It also updates the `README.md` to link to this new guide.

The CI/CD pipeline in `.github/workflows/ci.yml` is updated to push Docker images to AWS ECR instead of Docker Hub.