### PR TITLE
Fix: Allow frontend development server on port 5173 for CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ This project is designed for cloud deployment. Here are the instructions for dep
 - **Key Activities:** Integrated `aedes` (embedded MQTT broker) and `mqtt` (client library), designed topic structure, implemented command publishing and status update handling, and established a closed-loop system for device control and feedback.
 - **Outcome:** A fully functional IoT backend capable of communicating with real-world devices.
 
+### CORS Configuration Update for Development
+
+**Reasoning:** The frontend application was running on `http://localhost:5173`, but the backend API was configured to only allow requests from `http://localhost:3000` during development. This caused Cross-Origin Resource Sharing (CORS) errors, preventing the frontend from communicating with the API.
+
+**Changes Made:**
+- In `src/app.ts`, the `cors` middleware's `origin` setting for development environments was updated from `"http://localhost:3000"` to `"http://localhost:5173"`.
+- In `src/server.ts`, the `cors` configuration for Socket.IO was updated to include `"http://localhost:5173"` in the list of allowed origins for development.
+
+This change ensures that the frontend running on `http://localhost:5173` can successfully connect to the backend API during development.
+
 ## 🧪 Testing
 
 ### Running Tests

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,7 +21,7 @@ app.use(
   cors({
     origin:
       env.NODE_ENV === "development"
-        ? "http://localhost:3000"
+        ? "http://localhost:5173"
         : "YOUR_FRONTEND_DOMAIN",
     credentials: true,
   }),

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,7 +20,7 @@ const PORT = env.PORT;
     cors: {
       origin:
         env.NODE_ENV === "development"
-          ? ["http://localhost:3000", "http://127.0.0.1:5500"]
+          ? ["http://localhost:5173", "http://localhost:3000", "http://127.0.0.1:5500"]
           : "YOUR_FRONTEND_DOMAIN",
       methods: ["GET", "POST"],
       credentials: true,


### PR DESCRIPTION
The frontend application was running on http://localhost:5173, but the backend API's CORS configuration for development environments was set to only allow http://localhost:3000. This mismatch caused Cross-Origin Resource Sharing (CORS) errors, preventing the frontend from connecting to the API.

This commit updates the \'Access-Control-Allow-Origin\' header in both src/app.ts (for Express) and src/server.ts (for Socket.IO) to include http://localhost:5173.

The change is also documented in README.md under a new section "CORS Configuration Update for Development".